### PR TITLE
Fix comment typo in ECS module

### DIFF
--- a/terraform/modules/ecs/ecs.tf
+++ b/terraform/modules/ecs/ecs.tf
@@ -35,7 +35,7 @@ resource "aws_ecs_cluster_capacity_providers" "ecs-capacity_provider" {
 
 
 //ECS Task definition
-//TODO: Ensure ecr repositry uri is being referenced correctly
+//TODO: Ensure ecr repository uri is being referenced correctly
 resource "aws_ecs_task_definition" "ecs-task-definition" {
   family = "ecs-task-definition"
   network_mode          = "awsvpc"


### PR DESCRIPTION
## Summary
- fix typo in `terraform/modules/ecs/ecs.tf` comment

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68400c120fa4832d9cb6019b43f369a9